### PR TITLE
Handle GitHub API rate limit quietly

### DIFF
--- a/backend/src/data/github/rest/__init__.py
+++ b/backend/src/data/github/rest/__init__.py
@@ -1,7 +1,7 @@
 from src.data.github.rest.commit import get_commit_files
 from src.data.github.rest.models import RawCommit, RawCommitFile
 from src.data.github.rest.repo import get_repo_commits, get_repo_stargazers
-from src.data.github.rest.template import RESTError
+from src.data.github.rest.template import RESTError, RESTErrorNotFound
 from src.data.github.rest.user import get_user, get_user_starred_repos
 
 __all__ = [
@@ -13,4 +13,5 @@ __all__ = [
     "RawCommit",
     "RawCommitFile",
     "RESTError",
+    "RESTErrorNotFound",
 ]

--- a/backend/src/data/github/rest/repo.py
+++ b/backend/src/data/github/rest/repo.py
@@ -3,12 +3,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from src.data.github.rest.models import RawCommit
-from src.data.github.rest.template import (
-    RESTError,
-    RESTErrorEmptyRepo,
-    get_template,
-    get_template_plural,
-)
+from src.data.github.rest.template import RESTError, get_template, get_template_plural
 
 BASE_URL = "https://api.github.com/repos/"
 
@@ -172,7 +167,7 @@ def get_repo_commits(
             return RawCommit.parse_obj(temp)
 
         return list(map(extract_info, data))
-    except (RESTErrorEmptyRepo, RESTError):
+    except RESTError:
         return []
     except Exception as e:
         logging.exception(e)

--- a/backend/src/data/github/rest/template.py
+++ b/backend/src/data/github/rest/template.py
@@ -14,11 +14,19 @@ class RESTError(Exception):
     pass
 
 
-class RESTErrorEmptyRepo(Exception):
+class RESTErrorUnauthorized(RESTError):
     pass
 
 
-class RESTErrorTimeout(Exception):
+class RESTErrorNotFound(RESTError):
+    pass
+
+
+class RESTErrorEmptyRepo(RESTError):
+    pass
+
+
+class RESTErrorTimeout(RESTError):
     pass
 
 
@@ -53,6 +61,12 @@ def _get_template(
     if r.status_code == 200:
         print("REST API", new_access_token, datetime.now() - start)
         return r.json()  # type: ignore
+
+    if r.status_code == 401:
+        raise RESTErrorUnauthorized("REST Error: Unauthorized")
+
+    if r.status_code == 404:
+        raise RESTErrorNotFound("REST Error: Not Found")
 
     if r.status_code == 409:
         raise RESTErrorEmptyRepo("REST Error: Empty Repository")

--- a/backend/src/publisher/processing/pubsub.py
+++ b/backend/src/publisher/processing/pubsub.py
@@ -12,8 +12,8 @@ async def publish_user(
 ):
     if PROD or DOCKER:
         publish_to_topic(
-            "user",
-            {
+            topic="user",
+            message={
                 "user_id": user_id,
                 "access_token": access_token,
                 "private_access": private_access,


### PR DESCRIPTION
Redirects users to empty wrapped screen, instead of falsely claiming invalid user or user not starred repo. Closes #192 