### PR TITLE
fix: current year in footer

### DIFF
--- a/frontend/src/pages/App/Footer.js
+++ b/frontend/src/pages/App/Footer.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { CURR_YEAR } from '../../constants';
 
 function Footer() {
   return (
@@ -7,7 +6,7 @@ function Footer() {
       <div className="bg-gray-100 border-t border-gray-300">
         <div className="container mx-auto py-4 px-5">
           <p className="text-gray-500 text-sm text-center">
-            {`© ${CURR_YEAR} GitHub Trends`}
+            {`© ${new Date().getFullYear()} GitHub Trends`}
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Problem
Current year in the footer was hardcoded to 2023 through a `CURR_YEAR` constant, which meant it would only update when someone updated that constant every year.

## Changes Made
- Used javascript's in-built `new Date().getFullYear()` to replace the hardcoded year in the footer.
- Also removed the import of that constant in the same file.

Initially i wanted to change the `CURR_YEAR` constant itself to `new Date().getFullYear()` but i didn't end up doing that as that may break some functionality in `src/pages/Wrapped/Wrapped.js`

## Screenshots
### Before
![Screenshot from 2024-01-10 19-33-56](https://github.com/avgupta456/github-trends/assets/77718741/e50e3669-e9bd-48d4-80d0-30ca43a6daba)
### After
![Screenshot from 2024-01-10 19-34-34](https://github.com/avgupta456/github-trends/assets/77718741/a1e61f05-a4d1-4f17-bf13-d8a236197c29)

